### PR TITLE
Make resizing top/left/height/width fields mutable to allow restricti…

### DIFF
--- a/WebSharper.JQueryUI/Resizable.fs
+++ b/WebSharper.JQueryUI/Resizable.fs
@@ -19,19 +19,19 @@ open WebSharper.Html.Client
 type ResizablePosition =
     {
         [<Name "left">]
-        Left : int
+        mutable Left : int
 
         [<Name "top">]
-        Top : int
+        mutable Top : int
     }
 
 type ResizableSize =
     {
         [<Name "width">]
-        Width : int
+        mutable Width : int
 
         [<Name "height">]
-        Height : int
+        mutable Height : int
     }
 
 type ResizableEvent =


### PR DESCRIPTION
In order to be able to restrict the size as the handle is being dragged, the height/width fields need to be mutable. (Presumably this also works for left/top although I haven't tried it)

See:
http://api.jqueryui.com/resizable/#event-resize

    $( ".selector" ).resizable({
      resize: function( event, ui ) {
        ui.size.height = Math.round( ui.size.height / 30 ) * 30;
      }
    });

