### PR TITLE
Fix bug in Autocomplete.

### DIFF
--- a/WebSharper.JQueryUI.Tests/Main.fs
+++ b/WebSharper.JQueryUI.Tests/Main.fs
@@ -67,9 +67,7 @@ module internal Client =
         )
         Div [acc2] -< [button]
 
-    let TestAutocomplete () =
-        let conf = new AutocompleteConfiguration()
-        conf.Source <- [|"Apa"; "Beta"; "Zeta" ; "Zebra"|]
+    let RunAutocompleter conf =
         let a = Autocomplete.New(Input [], conf)
         a |> OnBeforeRender (fun _ -> Log "Before Render")
         a |> OnAfterRender ( fun _ -> Log "After Render")
@@ -88,6 +86,32 @@ module internal Client =
             bClose
             bDestroy
         ]
+
+    let TestAutocomplete1 () =
+        let conf = new AutocompleteConfiguration()
+        conf.Source <| Listing [|"Apa"; "Beta"; "Zeta" ; "Zebra"|]
+        RunAutocompleter conf
+
+    let TestAutocomplete2 () =
+        let conf = new AutocompleteConfiguration()
+        let x : array<AutocompleteItem> =
+            [|{Label = "test"; Value = "value"}|]
+        conf.Source <| Items x
+        RunAutocompleter conf
+
+    let TestAutocomplete3 () =
+        let conf = new AutocompleteConfiguration()
+        let completef (_ : AutocompleteRequest, f : array<AutocompleteItem> -> unit) =
+            let x : array<AutocompleteItem> =
+                [|{Label = "test"; Value = "value"}|]
+            f x
+        conf.Source <| Callback completef
+        RunAutocompleter conf
+
+    let TestAutocomplete () =
+        TestAutocomplete1 ()
+        TestAutocomplete2 ()
+        TestAutocomplete3 ()
 
     let TestButton () =
         let b1 = JQueryUI.Button.New ("Click")
@@ -288,7 +312,7 @@ module internal Client =
         let img = Div [Style "background:url(http://www.look4design.co.uk/l4design/companies/light-iq/image14.jpg);height:100px;width:100px" ]
         let resizable = Resizable.New img
         resizable.OnStart  (fun _ _ -> Log("Started!"))
-        resizable.OnResize (fun event ui -> 
+        resizable.OnResize (fun event ui ->
             if ui.Size.Width > 300 then
                 ui.Size.Width <- 300
             if ui.Size.Height < 200  then
@@ -303,7 +327,8 @@ module internal Client =
         let tab =
             [
                 "Accordion", TestAccordion ()
-                "Autocomplete", TestAutocomplete ()
+                "Autocomplete1", TestAutocomplete1 ()
+                "Autocomplete2", TestAutocomplete2 ()
                 "Button", TestButton ()
                 "Datepicker", TestDatepicker ()
                 "Draggable", TestDraggable ()

--- a/WebSharper.JQueryUI/Autocomplete.fs
+++ b/WebSharper.JQueryUI/Autocomplete.fs
@@ -31,7 +31,23 @@ type AutocompleteItem =
         Value : string
     }
 
+type AutocompleteCallback =
+    AutocompleteRequest * (AutocompleteItem[] -> unit) -> unit
+
+[<JavaScript>]
+type AutocompleteSource =
+    | Listing of array<string>
+    | Items of array<AutocompleteItem>
+    | Url of string
+    | Callback of AutocompleteCallback
+
 type AutocompleteConfiguration[<JavaScript>]() =
+
+    [<DefaultValue>]
+    val mutable source : obj
+
+    [<Direct "this.source=function(x, y) { $scall([x, y]) }">]
+    let setCallback (scall : AutocompleteCallback) = ()
 
     [<Name "appendTo">]
     [<Stub>]
@@ -57,21 +73,13 @@ type AutocompleteConfiguration[<JavaScript>]() =
     [<Stub>]
     member val Position = Unchecked.defaultof<PositionConfiguration> with get, set
 
-    [<Name "source">]
-    [<Stub>]
-    member val Source = Unchecked.defaultof<array<string>> with get, set
-
-    [<Name "source">]
-    [<Stub>]
-    member val SourceItems = Unchecked.defaultof<array<AutocompleteItem>> with get, set
-
-    [<Name "source">]
-    [<Stub>]
-    member val SourceUrl = Unchecked.defaultof<string> with get, set
-
-    [<Name "source">]
-    [<Stub>]
-    member val SourceCallback = Unchecked.defaultof<AutocompleteRequest * (AutocompleteItem[] -> unit) -> unit> with get, set
+    [<JavaScript>]
+    member this.Source (s : AutocompleteSource) =
+        match s with
+            | Listing x -> this.source <- unbox x
+            | Items x -> this.source <- unbox x
+            | Url x -> this.source <- unbox x
+            | Callback x -> setCallback x
 
 module internal AutocompleteInternal =
     [<Inline "jQuery($el).autocomplete($conf)">]


### PR DESCRIPTION
In the original version, ```[<Name "source">]``` was used for each type of completer. This resulted in WebSharper generating four distinct target values (i.e. ```source, source1, source2, source3```), which caused autocomplete to fail for all but the first completer (simple array). Furthermore, ```autocomplete()``` in JQueryUI.js expects a callback with two arguments, but the translated (F#) callback expects an array with two elements. This is fixed by bridging the call to the F# function.
