### PR TITLE
Datepicker widget: missing features and some bugfixes

### DIFF
--- a/WebSharper.JQueryUI.Tests/Main.fs
+++ b/WebSharper.JQueryUI.Tests/Main.fs
@@ -123,12 +123,69 @@ module internal Client =
         )
         Div [b1; b2]
 
-    let TestDatepicker () =
+    let TestDatepicker1 () =
         let conf = new DatepickerConfiguration()
         let dp = Datepicker.New(Input [], conf)
         dp |> OnAfterRender(fun _ -> Log "Dp After Render")
         dp |> OnBeforeRender(fun _ -> Log "Dp Before Render")
         Div [dp]
+
+    let TestDatepicker2 () =
+        let conf = new DatepickerConfiguration(AutoSize = true)
+        let dp = Datepicker.New(Input [],conf)
+
+        dp.OnClose(fun dt elem ->
+            Log "Dp2 OnClose"
+            Console.Log dt
+            Console.Log elem
+        )
+        dp.OnSelect(fun dt elem ->
+            Log "Dp2 OnSelect"
+            Console.Log dt
+            Console.Log elem
+        )
+
+        dp
+        |> OnAfterRender (fun picker ->
+            picker.Option("changeYear", true)
+        )
+        dp |> OnAfterRender(fun picker -> 
+            Log "Dp2 After Render"
+            Log (picker.Option("changeYear").ToString())
+            Log (picker.Option("autoSize").ToString())
+            Console.Log <| picker.Option()
+        )
+        dp |> OnBeforeRender(fun _ -> Log "Dp2 Before Render")
+        Div [dp]
+
+    let TestDatepicker3 () =
+        let conf = 
+            new DatepickerConfiguration(
+                AutoSize = true,
+                OnClose = (
+                    fun dt ->
+                        Log "Dp3 OnClose"
+                        Console.Log dt),
+                OnSelect = (
+                    fun dt ->
+                        Log "Dp3 OnSelect"
+                        Console.Log dt)
+            )
+        let dp = Datepicker.New(Input [],conf)
+
+        dp
+        |> OnAfterRender (fun picker ->
+            picker.Option("changeYear", true)
+        )
+        dp |> OnAfterRender(fun picker -> 
+            Log "Dp3 After Render"
+            Log (picker.Option("changeYear").ToString())
+            Log (picker.Option("autoSize").ToString())
+            Console.Log <| picker.Option()
+        )
+        dp |> OnBeforeRender(fun _ -> Log "Dp3 Before Render")
+        Div [dp]
+
 
     let TestDraggable () =
         let d =
@@ -326,7 +383,9 @@ module internal Client =
                 "Autocomplete2", TestAutocomplete2 ()
                 "Autocomplete3", TestAutocomplete3 ()
                 "Button", TestButton ()
-                "Datepicker", TestDatepicker ()
+                "Datepicker1", TestDatepicker1 ()
+                "Datepicker2", TestDatepicker2 ()
+                "Datepicker3", TestDatepicker3 ()
                 "Draggable", TestDraggable ()
                 "Dialog", TestDialog ()
                 "Progressbar", TestProgressbar ()

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,9 +4,9 @@ source https://nuget.intellifactory.com/nuget username: "%IF_USER%" password: "%
 
 storage: none
 
-nuget WebSharper.Html prerelease
-nuget WebSharper prerelease
-nuget WebSharper.FSharp prerelease
+nuget WebSharper.Html
+nuget WebSharper
+nuget WebSharper.FSharp
 
 group build
     framework: net45

--- a/paket.lock
+++ b/paket.lock
@@ -2,10 +2,9 @@ STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
     IntelliFactory.Xml (0.6.64.1)
-  remote: https://nuget.intellifactory.com/nuget
-    WebSharper (4.3.0.274)
-    WebSharper.FSharp (4.3.0.274)
-      WebSharper (4.3.0.274)
+    WebSharper (4.3.1.275)
+    WebSharper.FSharp (4.3.1.275)
+      WebSharper (4.3.1.275)
     WebSharper.Html (4.3.0.136)
       IntelliFactory.Xml (>= 0.6.64 < 0.7)
       WebSharper (>= 4.3 < 4.4)
@@ -16,11 +15,11 @@ NUGET
   remote: https://api.nuget.org/v3/index.json
     Chessie (0.6)
       FSharp.Core
-    FAKE (4.64.6)
-    FSharp.Compiler.Tools (10.0.1)
-    FSharp.Core (4.3.4)
-    Mono.Cecil (0.10.0-beta7)
-    Newtonsoft.Json (11.0.1)
+    FAKE (5.1)
+    FSharp.Compiler.Tools (10.0.2)
+    FSharp.Core (4.5)
+    Mono.Cecil (0.10)
+    Newtonsoft.Json (11.0.2)
     Paket.Core (5.141)
       Chessie (>= 0.6)
       FSharp.Compiler.Tools


### PR DESCRIPTION
- DatepickerConfiguration:
  - OnClose: Datepicker parameter has been removed as jquery seems to not pass it
  - OnSelect: added
- this.onChangeMonthYear: it was refering to the wrong javascript's counterpart
- On*: keeping the current configuration
- Option(): it is now returning the configuration structure instead of the datepicker reference
- Tests: new test scenarios for Datepicker